### PR TITLE
Fix for inference changes

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -283,7 +283,7 @@ impl<'a> SidekiqServer<'a> {
             .hset_multiple(self.with_namespace(&self.identity()), &content)
             .expire(self.with_namespace(&self.identity()), 5)
             .sadd(self.with_namespace(&"processes"), self.identity())
-            .query(&*conn));
+            .query::<()>(&*conn));
 
         Ok(())
 


### PR DESCRIPTION
Hi,

Some recent [future-compatibility testing](https://github.com/rust-lang/rust/pull/39009#issuecomment-276806189) showed up an issue in this crate. In the future, creating a value of type `T` where `T` is unspecified and can't be inferred will cause the compiler to either give an error or default `T` to `!` (where it currently defaults to `()`).

This PR makes it so you're explicitly querying for a `()`.